### PR TITLE
Fix a few typos

### DIFF
--- a/3_modules.md
+++ b/3_modules.md
@@ -137,7 +137,7 @@ m2.d.thing += # this will fail
 
 ## Ports
 
-The equivalent of ports in a module is public attributes. In the following example, `a` and `data` are publically available to other modules, while `b` is not, just as `a` and `data` are publically available to other Python classes, and `b` is not.
+The equivalent of ports in a module is public attributes. In the following example, `a` and `data` are publicly available to other modules, while `b` is not, just as `a` and `data` are publicly available to other Python classes, and `b` is not.
 
 ```python
 class ThingBlock(Elaboratable):

--- a/4_basicops.md
+++ b/4_basicops.md
@@ -29,7 +29,7 @@ However, many math operators are overridable in Python, since these translate to
 | `<`      | less than                |
 | `<=`     | less than or equal to    |
 
-Note that there are no translatable Python logical operators (`and`, `or`). The logical reduction functions `any` and `all` are also not avaiable in nMigen expressions.  Attempts to use an nMigen value as a boolean will result in an error saying `Attempted to convert nMigen value to boolean`.
+Note that there are no translatable Python logical operators (`and`, `or`). The logical reduction functions `any` and `all` are also not available in nMigen expressions.  Attempts to use an nMigen value as a boolean will result in an error saying `Attempted to convert nMigen value to boolean`.
 
 Shift right is effectively arithmetic, where the sign bit is present for signed Values, or absent (or implicitly zero) for unsigned Values. Consider that if right shift is applied to a signed Value, the shift properly duplicates the sign bit. If it is applied to an unsigned Value, the shift is logical -- you could consider it an arithmetic shift where the "missing" sign bit is always zero. Because shift right on an unsigned Value is the same as logical shift right, `>>` is a logical shift right when applied to an unsigned Value.
 

--- a/5_branching.md
+++ b/5_branching.md
@@ -28,7 +28,7 @@ If `platform` is `"this"` then only `statement1` will appear in the generated ha
 
 ### Conditions
 
-The conditions in `If-Elif-Else` are comparisons, for example `a == 1` or `(a >= b) & (a <= c)`. Note that in this latter example, we used parentheses around each term. Each comparison, in essense, becomes a one-bit signal, and `&` is a _bit-wise operator_, not the logical `and`. When in doubt, just use parentheses.
+The conditions in `If-Elif-Else` are comparisons, for example `a == 1` or `(a >= b) & (a <= c)`. Note that in this latter example, we used parentheses around each term. Each comparison, in essence, becomes a one-bit signal, and `&` is a _bit-wise operator_, not the logical `and`. When in doubt, just use parentheses.
 
 If you have a signal with more than one bit and use it as the condition, as in `with m.If(a):`, then the condition will be true if any bit in `a` is 1.
 

--- a/6_combining.md
+++ b/6_combining.md
@@ -243,7 +243,7 @@ class BusLayout(Layout):
     def __init__(self):
         super().__init__([
             ("data", unsigned(8)),
-            ("addr", unsigned(16))
+            ("addr", unsigned(16)),
             ("wr", 1),
             ("en", 1),
         ])


### PR DESCRIPTION
Thanks for the tutorial! A few small typos I found while reading:
- avaiable → available
- essense → essence
- publically → publicly (not strictly a typo but more common)
- add a missing ',' in bus example